### PR TITLE
add a list method which uses LPUSH, and will optionally limit the size of the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,15 @@ Use the following to store an RDD in a Redis List:
 sc.toRedisLIST(listRDD, listName, ("your.redis.server", 6379))
 ```
 
+Use the following to store an RDD in a fixed-size Redis List:
+
+```
+...
+sc.toRedisFixedLIST(listRDD, listName, ("your.redis.server", 6379), listSize)
+```
+
 The `listRDD` is an RDD that contains all of the list's string elements in order, and `listName` is the list's key name.
+`listSize` is an integer which specifies the size of the redis list; it is optional, and will default to an unlimited size.
 
 
 #### Sets


### PR DESCRIPTION
My use-case for this is I have a long-lived spark process to dump some testing events into different lists.  I'm more interested in seeing the most recent events, so `LPUSH` is more useful than `RPUSH`; and given this will be a long-lived process, I don't want to have to dump the db, or have another process go through and trim the keys.

I'm not a huge fan of the method signature (`sc.toRedisFixedLIST(listRDD, listName, ("your.redis.server", 6379), listSize)`), but this keeps the same signature as the other methods when `listSize` is not specified.

I'm also unsure how to test this, but I will make an attempt at it.  Suggestions would be appreciated.