### PR TITLE
Spark 2.0.1, two more methods for StreamingContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This library is work in progress so the API may change before the official relea
 
 ## Getting the library
 You can download the library's source and build it:
-```
+```shell
 git clone https://github.com/RedisLabs/spark-redis.git
 cd spark-redis
 mvn clean package -DskipTests
@@ -39,14 +39,14 @@ mvn clean package -DskipTests
 Jedis' current version - v2.7 - does not support reading from Redis cluster's slave nodes. This functionality will only be included in its upcoming version, v2.8.
 
 To use Spark-Redis with Redis cluster's slave nodes, the library's source includes a pre-release of Jedis v2.8 under the `with-slaves` branch. Switch to that branch by entering the following before running `mvn clean install`:
-```
+```shell
 git checkout with-slaves
 ```
 
 ## Using the library
 Add Spark-Redis to Spark with the `--jars` command line option. For example, use it from spark-shell, include it in the following manner:
 
-```
+```shell
 $ bin/spark-shell --jars <path-to>/spark-redis-<version>.jar,<path-to>/jedis-<version>.jar
 
 Welcome to
@@ -96,7 +96,7 @@ topology from the initial node, so there is no need to provide the rest of the c
 
 ### The keys RDD
 Since data access in Redis is based on keys, to use Spark-Redis you'll first need a keys RDD.  The following example shows how to read key names from Redis into an RDD:
-```
+```scala
 import com.redislabs.provider.redis._
 
 val keysRDD = sc.fromRedisKeyPattern("foo*", 5)
@@ -112,7 +112,7 @@ Each of Redis' data types can be read to an RDD. The following snippet demonstra
 
 #### Strings
 
-```
+```scala
 import com.redislabs.provider.redis._
 val stringRDD = sc.fromRedisKV("keyPattern*")
 val stringRDD = sc.fromRedisKV(Array("foo", "bar"))
@@ -121,7 +121,7 @@ val stringRDD = sc.fromRedisKV(Array("foo", "bar"))
 Once run, `stringRDD: RDD[(String, String)]` will contain the string values of all keys whose names are provided by keyPattern or Array[String].
 
 #### Hashes
-```
+```scala
 val hashRDD = sc.fromRedisHash("keyPattern*")
 val hashRDD = sc.fromRedisHash(Array("foo", "bar"))
 ```
@@ -129,14 +129,14 @@ val hashRDD = sc.fromRedisHash(Array("foo", "bar"))
 This will populate `hashRDD: RDD[(String, String)]` with the fields and values of the Redis Hashes, the hashes' names are provided by keyPattern or Array[String]
 
 #### Lists
-```
+```scala
 val listRDD = sc.fromRedisList("keyPattern*")
 val listRDD = sc.fromRedisList(Array("foo", "bar"))
 ```
 The contents (members) of the Redis Lists in whose names are provided by keyPattern or Array[String] will be stored in `listRDD: RDD[String]`
 
 #### Sets
-```
+```scala
 val setRDD = sc.fromRedisSet("keyPattern*")
 val setRDD = sc.fromRedisSet(Array("foo", "bar"))
 ```
@@ -144,21 +144,21 @@ val setRDD = sc.fromRedisSet(Array("foo", "bar"))
 The Redis Sets' members will be written to `setRDD: RDD[String]`.
 
 #### Sorted Sets
-```
+```scala
 val zsetRDD = sc.fromRedisZSetWithScore("keyPattern*")
 val zsetRDD = sc.fromRedisZSetWithScore(Array("foo", "bar"))
 ```
 
 Using `fromRedisZSetWithScore` will store in `zsetRDD: RDD[(String, Double)]`, an RDD that consists of members and their scores, from the Redis Sorted Sets whose keys are provided by keyPattern or Array[String].
 
-```
+```scala
 val zsetRDD = sc.fromRedisZSet("keyPattern*")
 val zsetRDD = sc.fromRedisZSet(Array("foo", "bar"))
 ```
 
 Using `fromRedisZSet` will store in `zsetRDD: RDD[String]`, an RDD that consists of members, from the Redis Sorted Sets whose keys are provided by keyPattern or Array[String].
 
-```
+```scala
 val startPos: Int = _
 val endPos: Int = _
 val zsetRDD = sc.fromRedisZRangeWithScore("keyPattern*", startPos, endPos)
@@ -167,7 +167,7 @@ val zsetRDD = sc.fromRedisZRangeWithScore(Array("foo", "bar"), startPos, endPos)
 
 Using `fromRedisZRangeWithScore` will store in `zsetRDD: RDD[(String, Double)]`, an RDD that consists of members and the members' ranges are within [startPos, endPos] of its own Sorted Set, from the Redis Sorted Sets whose keys are provided by keyPattern or Array[String].
 
-```
+```scala
 val startPos: Int = _
 val endPos: Int = _
 val zsetRDD = sc.fromRedisZRange("keyPattern*", startPos, endPos)
@@ -176,7 +176,7 @@ val zsetRDD = sc.fromRedisZRange(Array("foo", "bar"), startPos, endPos)
 
 Using `fromRedisZSet` will store in `zsetRDD: RDD[String]`, an RDD that consists of members and the members' ranges are within [startPos, endPos] of its own Sorted Set, from the Redis Sorted Sets whose keys are provided by keyPattern or Array[String].
 
-```
+```scala
 val min: Double = _
 val max: Double = _
 val zsetRDD = sc.fromRedisZRangeByScoreWithScore("keyPattern*", min, max)
@@ -185,7 +185,7 @@ val zsetRDD = sc.fromRedisZRangeByScoreWithScore(Array("foo", "bar"), min, max)
 
 Using `fromRedisZRangeByScoreWithScore` will store in `zsetRDD: RDD[(String, Double)]`, an RDD that consists of members and the members' scores are within [min, max], from the Redis Sorted Sets whose keys are provided by keyPattern or Array[String].
 
-```
+```scala
 val min: Double = _
 val max: Double = _
 val zsetRDD = sc.fromRedisZRangeByScore("keyPattern*", min, max)
@@ -200,7 +200,7 @@ To write data from Spark to Redis, you'll need to prepare the appropriate RDD de
 #### Strings
 For String values, your RDD should consist of the key-value pairs that are to be written. Assuming that the strings RDD is called `stringRDD`, use the following snippet for writing it to Redis:
 
-```
+```scala
 ...
 sc.toRedisKV(stringRDD)
 ```
@@ -208,7 +208,7 @@ sc.toRedisKV(stringRDD)
 #### Hashes
 To store a Redis Hash, the RDD should consist of its field-value pairs. If the RDD is called `hashRDD`, the following should be used for storing it in the key name specified by `hashName`:
 
-```
+```scala
 ...
 sc.toRedisHASH(hashRDD, hashName)
 ```
@@ -216,14 +216,14 @@ sc.toRedisHASH(hashRDD, hashName)
 #### Lists
 Use the following to store an RDD in a Redis List:
 
-```
+```scala
 ...
 sc.toRedisLIST(listRDD, listName)
 ```
 
 Use the following to store an RDD in a fixed-size Redis List:
 
-```
+```scala
 ...
 sc.toRedisFixedLIST(listRDD, listName, listSize)
 ```
@@ -235,7 +235,7 @@ The `listRDD` is an RDD that contains all of the list's string elements in order
 #### Sets
 For storing data in a Redis Set, use `toRedisSET` as follows:
 
-```
+```scala
 ...
 sc.toRedisSET(setRDD, setName)
 ```
@@ -243,7 +243,7 @@ sc.toRedisSET(setRDD, setName)
 Where `setRDD` is an RDD with the set's string elements and `setName` is the name of the key for that set.
 
 #### Sorted Sets
-```
+```scala
 ...
 sc.toRedisZSET(zsetRDD, zsetName)
 ```
@@ -256,7 +256,7 @@ Spark-Redis support streaming data from Redis instance/cluster, currently stream
 
 Use the following to get a `(listName, value)` stream from `foo` and `bar` list
 
-```
+```scala
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.apache.spark.storage.StorageLevel
 import com.redislabs.provider.redis._
@@ -269,7 +269,7 @@ ssc.awaitTermination()
 
 Use the following to get a `value` stream from `foo` and `bar` list
 
-```
+```scala
 import org.apache.spark.streaming.{Seconds, StreamingContext}
 import org.apache.spark.storage.StorageLevel
 import com.redislabs.provider.redis._
@@ -279,10 +279,34 @@ redisStream.print
 ssc.awaitTermination()
 ```
 
+To put new key/value pairs and update existing for each mini-batch in the stream
+
+```scala
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.StreamingContext
+import com.redislabs.provider.redis._
+val ssc: StreamingContext = initMyStreamingContext()
+val kv: DStream[(String, String)] = getMyKVStream()
+ssc.toRedisKV(kv, 1)
+```
+
+To put new key/value pairs and update existing for each mini-batch in the stream
+with individual ttl for each pair
+
+```scala
+import org.apache.spark.streaming.dstream.DStream
+import org.apache.spark.streaming.StreamingContext
+import com.redislabs.provider.redis._
+val ssc: StreamingContext = initMyStreamingContext()
+val kvt: DStream[(String, String, Int)] = getMyKVStreamWithTTLs()
+ssc.toRedisKVwithIndividualTTLs(kvt)
+```
+
+
 
 ### Connecting to Multiple Redis Clusters/Instances
 
-```
+```scala
 def twoEndpointExample ( sc: SparkContext) = {
   val redisConfig1 = new RedisConfig(new RedisEndpoint("127.0.0.1", 6379, "passwd"))
   val redisConfig2 = new RedisConfig(new RedisEndpoint("127.0.0.1", 7379))

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 // Your sbt build file. Guides on how to write one can be found at
 // http://www.scala-sbt.org/0.13/docs/index.html
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
 
-sparkVersion := "1.4.0"
+sparkVersion := "2.0.1"
 
 spName := "RedisLabs/spark-redis"
 
@@ -26,7 +26,12 @@ organizationHomepage := Some(url("https://redislabs.com"))
 // Add Spark components this package depends on, e.g, "mllib", ....
 sparkComponents ++= Seq("sql", "streaming")
 
-libraryDependencies ++= Seq( "redis.clients" % "jedis" % "2.7.2")
+libraryDependencies ++= Seq(
+  "redis.clients" % "jedis" % "2.8.1",
+  "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+)
+
+parallelExecution in Test := false
 
 // uncomment and change the value below to change the directory where your zip artifact will be created
 // spDistDirectory := target.value

--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,12 @@ sparkVersion := "2.0.1"
 
 spName := "RedisLabs/spark-redis"
 
-description := "A library for reading and writing data from and to Redis with Apache Spark, for Spark SQL and DataFrames."
+description :=
+  """A library for reading and writing data from and to Redis
+    | with Apache Spark, for Spark SQL and DataFrames.""".stripMargin
 
 // Don't forget to set the version
-version := "0.3.2"
+version := "0.3.3-SNAPSHOT"
 
 homepage := Some(url("https://github.com/RedisLabs/spark-redis"))
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.redislabs</groupId>
 	<artifactId>spark-redis</artifactId>
-	<version>0.3.2</version>
+	<version>0.3.3-SNAPSHOT</version>
 	<name>Spark-Redis</name>
 	<description>A Spark library for Redis</description>
 	<url>http://github.com/RedisLabs/spark-redis</url>
@@ -12,10 +12,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.7</java.version>
-		<scala.minor.version>2.10</scala.minor.version>
-		<scala.complete.version>${scala.minor.version}.4</scala.complete.version>
-		<jedis.version>2.7.2</jedis.version>
-		<spark.version>1.4.1</spark.version>
+		<scala.minor.version>2.11</scala.minor.version>
+		<scala.complete.version>${scala.minor.version}.8</scala.complete.version>
+		<jedis.version>2.8.1</jedis.version>
+		<spark.version>2.0.1</spark.version>
 	</properties>
 
 	<build>
@@ -232,7 +232,7 @@
 		<dependency>
 			<groupId>org.scalatest</groupId>
 			<artifactId>scalatest_${scala.minor.version}</artifactId>
-			<version>2.2.1</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 		</dependency>
     </dependencies>

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 // You may use this file to add plugin dependencies for sbt.
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.3")
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.5")
 
 resolvers += "bintray-spark-packages" at "https://dl.bintray.com/spark-packages/maven/"

--- a/src/main/scala/com/redislabs/provider/redis/sql/DefaultSource.scala
+++ b/src/main/scala/com/redislabs/provider/redis/sql/DefaultSource.scala
@@ -7,7 +7,7 @@ import com.redislabs.provider.redis._
 import com.redislabs.provider.redis.rdd.{Keys, RedisKeysRDD}
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLContext}
-import org.apache.spark.sql.catalyst.expressions.Row
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types._
 import redis.clients.jedis.Protocol

--- a/src/test/scala/com/redislabs/provider/redis/rdd/KeysClusterSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/KeysClusterSuite.scala
@@ -2,13 +2,13 @@ package com.redislabs.provider.redis.rdd
 
 import com.redislabs.provider.redis._
 import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfterAll, FunSuite, ShouldMatchers}
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 import redis.clients.util.JedisClusterCRC16
 
 import scala.collection.JavaConversions._
 import scala.io.Source.fromInputStream
 
-class KeysClusterSuite extends FunSuite with Keys with ENV with BeforeAndAfterAll with ShouldMatchers {
+class KeysClusterSuite extends FunSuite with Keys with ENV with BeforeAndAfterAll with Matchers {
 
   override def beforeAll() {
     super.beforeAll()

--- a/src/test/scala/com/redislabs/provider/redis/rdd/KeysStandaloneSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/KeysStandaloneSuite.scala
@@ -2,13 +2,13 @@ package com.redislabs.provider.redis.rdd
 
 import com.redislabs.provider.redis._
 import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfterAll, FunSuite, ShouldMatchers}
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 import redis.clients.util.JedisClusterCRC16
 
 import scala.collection.JavaConversions._
 import scala.io.Source.fromInputStream
 
-class KeysStandaloneSuite extends FunSuite with Keys with ENV with BeforeAndAfterAll with ShouldMatchers {
+class KeysStandaloneSuite extends FunSuite with Keys with ENV with BeforeAndAfterAll with Matchers {
 
   override def beforeAll() {
     super.beforeAll()

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisConfigSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisConfigSuite.scala
@@ -1,10 +1,10 @@
 package com.redislabs.provider.redis.rdd
 
 import com.redislabs.provider.redis._
-import org.scalatest.{FunSuite, ShouldMatchers}
+import org.scalatest.{FunSuite, Matchers}
 import redis.clients.util.JedisClusterCRC16
 
-class RedisConfigSuite extends FunSuite with ShouldMatchers {
+class RedisConfigSuite extends FunSuite with Matchers {
 
   val redisStandaloneConfig = new RedisConfig(new RedisEndpoint("127.0.0.1", 6379, "passwd"))
   val redisClusterConfig = new RedisConfig(new RedisEndpoint("127.0.0.1", 7379))

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisRDDClusterSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisRDDClusterSuite.scala
@@ -1,11 +1,11 @@
 package com.redislabs.provider.redis.rdd
 
 import org.apache.spark.{SparkContext, SparkConf}
-import org.scalatest.{BeforeAndAfterAll, ShouldMatchers, FunSuite}
+import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
 import scala.io.Source.fromInputStream
 import com.redislabs.provider.redis._
 
-class RedisRDDClusterSuite extends FunSuite with ENV with BeforeAndAfterAll with ShouldMatchers {
+class RedisRDDClusterSuite extends FunSuite with ENV with BeforeAndAfterAll with Matchers {
 
   override def beforeAll() {
     super.beforeAll()

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisRDDStandaloneSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisRDDStandaloneSuite.scala
@@ -1,11 +1,11 @@
 package com.redislabs.provider.redis.rdd
 
 import org.apache.spark.{SparkContext, SparkConf}
-import org.scalatest.{BeforeAndAfterAll, ShouldMatchers, FunSuite}
+import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
 import scala.io.Source.fromInputStream
 import com.redislabs.provider.redis._
 
-class RedisRDDStandaloneSuite extends FunSuite with ENV with BeforeAndAfterAll with ShouldMatchers {
+class RedisRDDStandaloneSuite extends FunSuite with ENV with BeforeAndAfterAll with Matchers {
 
   override def beforeAll() {
     super.beforeAll()

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisSparkSQLClusterSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisSparkSQLClusterSuite.scala
@@ -1,11 +1,11 @@
 package com.redislabs.provider.redis.rdd
 
 import org.apache.spark.{SparkContext, SparkConf}
-import org.scalatest.{BeforeAndAfterAll, ShouldMatchers, FunSuite}
+import org.scalatest.{BeforeAndAfterAll, Matchers, FunSuite}
 import org.apache.spark.sql.SQLContext
 import com.redislabs.provider.redis._
 
-class RedisSparkSQLClusterSuite extends FunSuite with ENV with BeforeAndAfterAll with ShouldMatchers {
+class RedisSparkSQLClusterSuite extends FunSuite with ENV with BeforeAndAfterAll with Matchers {
 
   var sqlContext: SQLContext = null
   override def beforeAll() {

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisSparkSQLStandaloneSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisSparkSQLStandaloneSuite.scala
@@ -3,9 +3,9 @@ package com.redislabs.provider.redis.rdd
 import com.redislabs.provider.redis._
 import org.apache.spark.sql.SQLContext
 import org.apache.spark.{SparkConf, SparkContext}
-import org.scalatest.{BeforeAndAfterAll, FunSuite, ShouldMatchers}
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
 
-class RedisSparkSQLStandaloneSuite extends FunSuite with ENV with BeforeAndAfterAll with ShouldMatchers {
+class RedisSparkSQLStandaloneSuite extends FunSuite with ENV with BeforeAndAfterAll with Matchers {
 
   var sqlContext: SQLContext = null
   override def beforeAll() {


### PR DESCRIPTION
Updated to Spark 2.0.1, which has minor API changes compared to 1.6,
added a couple of methods for storing DStreams to Redis, only what I currently need. 
Gained some speed with a bit of refactoring, measured that locally with ScalaMeter.
