### PR TITLE
FIX: MessageHandler throws IndexOutOfBoundsException with empty lists

### DIFF
--- a/src/main/scala/com/redislabs/provider/redis/streaming/RedisInputDStream.scala
+++ b/src/main/scala/com/redislabs/provider/redis/streaming/RedisInputDStream.scala
@@ -50,7 +50,7 @@ private class RedisReceiver[T: ClassTag](keys: Array[String],
       try {
         while(!isStopped) {
           val response = conn.blpop(2, key)
-          if (response == null) {
+          if (response == null || response.size() == 0) {
 
           } else if (classTag[T] == classTag[String]) {
             store(response.get(1).asInstanceOf[T])


### PR DESCRIPTION
I tried RedisInputDStream and found that when blpop an empty list, reponse is not null but an emtpy list, so MessageHandler would throw IndexOutOfBoundsException. Though it does no harm to my program, I think it's too annoying. So I add a filter to avoid this Exception. :)