### PR TITLE
dataframe enhancements

### DIFF
--- a/doc/dataframe.md
+++ b/doc/dataframe.md
@@ -289,6 +289,8 @@ df.show()
 Spark-Redis tries to extract the key based on the key pattern:
 - if the pattern ends with `*` and it's the only wildcard, the trailing substring will be extracted
 - otherwise there is no extraction - the key is kept as is, e.g.
+
+
       ```scala
       val df = // code omitted...
                   .option("keys.pattern", "p*:*")

--- a/doc/dataframe.md
+++ b/doc/dataframe.md
@@ -303,6 +303,7 @@ Spark-Redis tries to extract the key based on the key pattern:
       | John| 30| person:John|
       |Peter| 45|person:Peter|
       +-----+---+------------+
+      ```
 
 Another option is to let spark-redis automatically infer schema based on a random row. In this case all columns will have `String` type. 
 Also we don't specify `key.column` option in this example, so the column `_id` will be created. 

--- a/doc/dataframe.md
+++ b/doc/dataframe.md
@@ -290,22 +290,22 @@ Spark-Redis tries to extract the key based on the key pattern:
 - if the pattern ends with `*` and it's the only wildcard, the trailing substring will be extracted
 - otherwise there is no extraction - the key is kept as is, e.g.
 
+    ```scala
+    val df = // code omitted...
+                .option("keys.pattern", "p*:*")
+                .option("key.column", "id")
+                .load()
+    df.show()
+    ```
 
-      ```scala
-      val df = // code omitted...
-                  .option("keys.pattern", "p*:*")
-                  .option("key.column", "id")
-                  .load()
-      df.show()
-      ```
-      ```bash
-      +-----+---+------------+
-      | name|age|          id|
-      +-----+---+------------+
-      | John| 30| person:John|
-      |Peter| 45|person:Peter|
-      +-----+---+------------+
-      ```
+    ```bash
+    +-----+---+------------+
+    | name|age|          id|
+    +-----+---+------------+
+    | John| 30| person:John|
+    |Peter| 45|person:Peter|
+    +-----+---+------------+
+    ```
 
 Another option is to let spark-redis automatically infer schema based on a random row. In this case all columns will have `String` type. 
 Also we don't specify `key.column` option in this example, so the column `_id` will be created. 

--- a/doc/dataframe.md
+++ b/doc/dataframe.md
@@ -332,15 +332,16 @@ root
 
 ## DataFrame options
 
-| Name              | Description                                                                               | Type                  | Default |
-| ----------------- | ------------------------------------------------------------------------------------------| --------------------- | ------- |
-| model             | defines Redis model used to persist DataFrame, see [Persistence model](#persistence-model)| `enum [binary, hash]` | `hash`  |
-| partitions.number | number of partitions (applies only when reading dataframe)                                | `Int`                 | `3`     |
-| key.column        | when writing - specifies unique column used as a Redis key, by default a key is auto-generated. <br/> When reading - specifies column name to store hash key | `String`              | -       |
-| ttl               | data time to live in `seconds`. Data doesn't expire if `ttl` is less than `1`             | `Int`                 | `0`     |
-| infer.schema      | infer schema from random row, all columns will have `String` type                         | `Boolean`             | `false` |
-| max.pipeline.size | maximum number of commands per pipeline (used to batch commands)                          | `Int`                 | 100     |
-| scan.count        | count option of SCAN command (used to iterate over keys)                                  | `Int`                 | 100     |
+| Name                | Description                                                                               | Type                  | Default |
+| ------------------- | ------------------------------------------------------------------------------------------| --------------------- | ------- |
+| model               | defines Redis model used to persist DataFrame, see [Persistence model](#persistence-model)| `enum [binary, hash]` | `hash`  |
+| filter.keys.by.type | make sure the underlying data structures match persistence model                          | `Boolean`             | `false` |
+| partitions.number   | number of partitions (applies only when reading dataframe)                                | `Int`                 | `3`     |
+| key.column          | when writing - specifies unique column used as a Redis key, by default a key is auto-generated. <br/> When reading - specifies column name to store hash key | `String`              | -       |
+| ttl                 | data time to live in `seconds`. Data doesn't expire if `ttl` is less than `1`             | `Int`                 | `0`     |
+| infer.schema        | infer schema from random row, all columns will have `String` type                         | `Boolean`             | `false` |
+| max.pipeline.size   | maximum number of commands per pipeline (used to batch commands)                          | `Int`                 | 100     |
+| scan.count          | count option of SCAN command (used to iterate over keys)                                  | `Int`                 | 100     |
 
 
 ## Known limitations

--- a/doc/dataframe.md
+++ b/doc/dataframe.md
@@ -332,16 +332,17 @@ root
 
 ## DataFrame options
 
-| Name                | Description                                                                               | Type                  | Default |
-| ------------------- | ------------------------------------------------------------------------------------------| --------------------- | ------- |
-| model               | defines Redis model used to persist DataFrame, see [Persistence model](#persistence-model)| `enum [binary, hash]` | `hash`  |
-| filter.keys.by.type | make sure the underlying data structures match persistence model                          | `Boolean`             | `false` |
-| partitions.number   | number of partitions (applies only when reading dataframe)                                | `Int`                 | `3`     |
-| key.column          | when writing - specifies unique column used as a Redis key, by default a key is auto-generated. <br/> When reading - specifies column name to store hash key | `String`              | -       |
-| ttl                 | data time to live in `seconds`. Data doesn't expire if `ttl` is less than `1`             | `Int`                 | `0`     |
-| infer.schema        | infer schema from random row, all columns will have `String` type                         | `Boolean`             | `false` |
-| max.pipeline.size   | maximum number of commands per pipeline (used to batch commands)                          | `Int`                 | 100     |
-| scan.count          | count option of SCAN command (used to iterate over keys)                                  | `Int`                 | 100     |
+| Name                   | Description                                                                               | Type                  | Default |
+| -----------------------| ------------------------------------------------------------------------------------------| --------------------- | ------- |
+| model                  | defines Redis model used to persist DataFrame, see [Persistence model](#persistence-model)| `enum [binary, hash]` | `hash`  |
+| filter.keys.by.type    | make sure the underlying data structures match persistence model                          | `Boolean`             | `false` |
+| partitions.number      | number of partitions (applies only when reading dataframe)                                | `Int`                 | `3`     |
+| key.column             | when writing - specifies unique column used as a Redis key, by default a key is auto-generated. <br/> When reading - specifies column name to store hash key | `String`              | -       |
+| ttl                    | data time to live in `seconds`. Data doesn't expire if `ttl` is less than `1`             | `Int`                 | `0`     |
+| infer.schema           | infer schema from random row, all columns will have `String` type                         | `Boolean`             | `false` |
+| max.pipeline.size      | maximum number of commands per pipeline (used to batch commands)                          | `Int`                 | 100     |
+| scan.count             | count option of SCAN command (used to iterate over keys)                                  | `Int`                 | 100     |
+| iterator.grouping.size | the number of items to be grouped when iterating over underlying RDD partition            | `Int`                 | 1000    |
 
 
 ## Known limitations

--- a/doc/dataframe.md
+++ b/doc/dataframe.md
@@ -113,21 +113,6 @@ val df = spark.read
   .load()
 ```
 
-Otherwise, a column with name `_id` of type `String` will be created:
-
-```bash
-root
- |-- _id: string (nullable = true)
- |-- age: integer (nullable = false)
-
-+-----+---+
-|  _id|age|
-+-----+---+
-| John| 30|
-|Peter| 45|
-+-----+---+
-```
-
 ### Save Modes
 
 Spark-redis supports all DataFrame [SaveMode](https://spark.apache.org/docs/latest/sql-programming-guide.html#save-modes)'s: `Append`, 

--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -67,8 +67,10 @@ case class RedisEndpoint(host: String = Protocol.DEFAULT_HOST,
     ConnectionPool.connect(this)
   }
 
+  /**
+    * @return config with masked password. Used for logging.
+    */
   def maskPassword(): RedisEndpoint = {
-    // mask password
     this.copy(auth = "")
   }
 }

--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -64,7 +64,11 @@ case class RedisEndpoint(host: String = Protocol.DEFAULT_HOST,
     * @return a new Jedis instance
     */
   def connect(): Jedis = {
-    ConnectionPool.connect(this)
+//    val start = System.currentTimeMillis()
+    val r = ConnectionPool.connect(this)
+//    val end = System.currentTimeMillis()
+//    println(s"Connect $this ${end - start}")
+    r
   }
 }
 

--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -64,11 +64,12 @@ case class RedisEndpoint(host: String = Protocol.DEFAULT_HOST,
     * @return a new Jedis instance
     */
   def connect(): Jedis = {
-//    val start = System.currentTimeMillis()
-    val r = ConnectionPool.connect(this)
-//    val end = System.currentTimeMillis()
-//    println(s"Connect $this ${end - start}")
-    r
+    ConnectionPool.connect(this)
+  }
+
+  def maskPassword(): RedisEndpoint = {
+    // mask password
+    this.copy(auth = "")
   }
 }
 

--- a/src/main/scala/com/redislabs/provider/redis/package.scala
+++ b/src/main/scala/com/redislabs/provider/redis/package.scala
@@ -1,3 +1,7 @@
 package com.redislabs.provider
 
-package object redis extends RedisFunctions
+package object redis extends RedisFunctions {
+
+  val RedisDataTypeHash: String = "hash"
+  val RedisDataTypeString: String = "string"
+}

--- a/src/main/scala/com/redislabs/provider/redis/rdd/RedisRDD.scala
+++ b/src/main/scala/com/redislabs/provider/redis/rdd/RedisRDD.scala
@@ -247,7 +247,6 @@ class RedisKeysRDD(sc: SparkContext,
     val partition: RedisPartition = split.asInstanceOf[RedisPartition]
     val sPos = partition.slots._1
     val ePos = partition.slots._2
-
     val nodes = partition.redisConfig.getNodesBySlots(sPos, ePos)
 
     if (Option(this.keys).isDefined) {

--- a/src/main/scala/com/redislabs/provider/redis/rdd/RedisRDD.scala
+++ b/src/main/scala/com/redislabs/provider/redis/rdd/RedisRDD.scala
@@ -45,7 +45,7 @@ class RedisKVRDD(prev: RDD[String],
       val res = stringKeys.zip(response).iterator.asInstanceOf[Iterator[(String, String)]]
       conn.close()
       res
-    }.iterator
+    }
   }
 
   def getHASH(nodes: Array[RedisNode], keys: Iterator[String]): Iterator[(String, String)] = {
@@ -55,7 +55,7 @@ class RedisKVRDD(prev: RDD[String],
       val res = hashKeys.flatMap(conn.hgetAll).iterator
       conn.close()
       res
-    }.iterator
+    }
   }
 }
 
@@ -84,7 +84,7 @@ class RedisListRDD(prev: RDD[String],
       val res = setKeys.flatMap(conn.smembers).iterator
       conn.close()
       res
-    }.iterator
+    }
   }
 
   def getLIST(nodes: Array[RedisNode], keys: Iterator[String]): Iterator[String] = {
@@ -94,7 +94,7 @@ class RedisListRDD(prev: RDD[String],
       val res = listKeys.flatMap(conn.lrange(_, 0, -1)).iterator
       conn.close()
       res
-    }.iterator
+    }
   }
 }
 
@@ -146,7 +146,7 @@ class RedisZSetRDD[T: ClassTag](prev: RDD[String],
       }
       conn.close()
       res
-    }.iterator.asInstanceOf[Iterator[T]]
+    }.asInstanceOf[Iterator[T]]
   }
 
   private def getZSetByScore(nodes: Array[RedisNode],
@@ -168,7 +168,7 @@ class RedisZSetRDD[T: ClassTag](prev: RDD[String],
       }
       conn.close()
       res
-    }.iterator.asInstanceOf[Iterator[T]]
+    }.asInstanceOf[Iterator[T]]
   }
 }
 
@@ -463,9 +463,9 @@ trait Keys {
     * @param keys  list of keys
     * @return (node: (key1, key2, ...), node2: (key3, key4,...), ...)
     */
-  def groupKeysByNode(nodes: Array[RedisNode], keys: Iterator[String]): Array[(RedisNode, Array[String])] = {
+  def groupKeysByNode(nodes: Array[RedisNode], keys: Iterator[String]): Iterator[(RedisNode, Array[String])] = {
     keys.map(key => (getMasterNode(nodes, key), key)).toArray.groupBy(_._1).
-      map(x => (x._1, x._2.map(_._2))).toArray
+      map(x => (x._1, x._2.map(_._2))).iterator
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
@@ -188,9 +188,7 @@ class RedisSourceRelation(override val sqlContext: SQLContext,
     * @return true if data exists in redis
     */
   def isEmpty: Boolean = {
-    val a = sc.fromRedisKeyPattern(dataKeyPattern, partitionNum = numPartitions).isEmpty()
-    println("check isempty")
-    a
+    sc.fromRedisKeyPattern(dataKeyPattern, partitionNum = numPartitions).isEmpty()
   }
 
   /**

--- a/src/main/scala/org/apache/spark/sql/redis/redis.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/redis.scala
@@ -6,6 +6,8 @@ package org.apache.spark.sql
 package object redis {
 
   val RedisFormat = "org.apache.spark.sql.redis"
+
+  val SqlOptionFilterKeysByType = "filter.keys.by.type"
   val SqlOptionNumPartitions = "partitions.number"
   /**
     * Default read operation number of partitions.

--- a/src/main/scala/org/apache/spark/sql/redis/redis.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/redis.scala
@@ -24,4 +24,7 @@ package object redis {
 
   val SqlOptionMaxPipelineSize = "max.pipeline.size"
   val SqlOptionScanCount = "scan.count"
+
+  val SqlOptionIteratorGroupingSize = "iterator.grouping.size"
+  val SqlOptionIteratorGroupingSizeDefault = 1000
 }

--- a/src/test/scala/com/redislabs/provider/redis/df/BinaryDataframeSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/BinaryDataframeSuite.scala
@@ -1,10 +1,14 @@
 package com.redislabs.provider.redis.df
 
+import com.redislabs.provider.redis.toRedisContext
+import com.redislabs.provider.redis.util.Person
 import com.redislabs.provider.redis.util.Person._
+import com.redislabs.provider.redis.util.TestUtils._
+import org.apache.commons.lang3.SerializationUtils
 import org.apache.spark.SparkException
+import org.apache.spark.sql.redis.RedisSourceRelation.tableDataKeyPattern
 import org.apache.spark.sql.redis._
 import org.scalatest.Matchers
-import com.redislabs.provider.redis.util.TestUtils._
 
 /**
   * @author The Viet Nguyen
@@ -55,4 +59,53 @@ trait BinaryDataframeSuite extends RedisDataframeSuite with Matchers {
         .show()
     }
   }
+
+  test("load filtered hash keys with strings") {
+    val tableName = generateTableName(TableNamePrefix)
+    val df = spark.createDataFrame(data)
+    df.write.format(RedisFormat)
+      .option(SqlOptionTableName, tableName)
+      .option(SqlOptionModel, SqlOptionModelHash)
+      .save()
+    val extraKey = RedisSourceRelation.uuid()
+    saveMap(tableName, extraKey, Person.dataMaps.head)
+    val loadedIds = spark.read.format(RedisFormat)
+      .schema(Person.fullSchema)
+      .option(SqlOptionTableName, tableName)
+      .option(SqlOptionModel, SqlOptionModelHash)
+      .option(SqlOptionFilterKeysByType, value = true)
+      .load()
+      .collect()
+      .map { r =>
+        r.getAs[String]("_id")
+      }
+    loadedIds.length shouldBe 2
+    loadedIds should not contain extraKey
+    val countAll = sc.fromRedisKeyPattern(tableDataKeyPattern(tableName)).count()
+    countAll shouldBe 3
+  }
+
+  test("load unfiltered hash keys with strings") {
+    val tableName = generateTableName(TableNamePrefix)
+    val df = spark.createDataFrame(data)
+    df.write.format(RedisFormat)
+      .option(SqlOptionTableName, tableName)
+      .option(SqlOptionModel, SqlOptionModelHash)
+      .save()
+    saveMap(tableName, RedisSourceRelation.uuid(), Person.dataMaps.head)
+    intercept[SparkException] {
+      spark.read.format(RedisFormat)
+        .option(SqlOptionTableName, tableName)
+        .option(SqlOptionModel, SqlOptionModelHash)
+        .load()
+        .collect()
+    }
+  }
+
+  def serialize(value: Map[String, String]): Array[Byte] = {
+    val valuesArray = value.values.toArray
+    SerializationUtils.serialize(valuesArray)
+  }
+
+  def saveMap(tableName: String, key: String, value: Map[String, String]): Unit
 }

--- a/src/test/scala/com/redislabs/provider/redis/df/benchmark/DataframeBenchmarkSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/benchmark/DataframeBenchmarkSuite.scala
@@ -112,4 +112,16 @@ trait DataframeBenchmarkSuite extends RedisDataframeSuite with RedisBenchmarks w
         }
     }
   }
+
+  test(s"$suiteTags, Take 10") {
+    time(s"$suiteTags, Take 10") {
+    time(s"$suiteTags, Take 10") {
+      spark.read.format(RedisFormat)
+        .option(SqlOptionModel, persistentModel)
+        .option(SqlOptionTableName, tableName)
+        .option(SqlOptionNumPartitions, 8)
+        .load()
+        .take(10)
+    }
+  }
 }

--- a/src/test/scala/com/redislabs/provider/redis/df/benchmark/DataframeBenchmarkSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/benchmark/DataframeBenchmarkSuite.scala
@@ -115,7 +115,6 @@ trait DataframeBenchmarkSuite extends RedisDataframeSuite with RedisBenchmarks w
 
   test(s"$suiteTags, Take 10") {
     time(s"$suiteTags, Take 10") {
-    time(s"$suiteTags, Take 10") {
       spark.read.format(RedisFormat)
         .option(SqlOptionModel, persistentModel)
         .option(SqlOptionTableName, tableName)

--- a/src/test/scala/com/redislabs/provider/redis/df/cluster/BinaryDataframeClusterSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/cluster/BinaryDataframeClusterSuite.scala
@@ -1,9 +1,22 @@
 package com.redislabs.provider.redis.df.cluster
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.redislabs.provider.redis.df.BinaryDataframeSuite
 import com.redislabs.provider.redis.env.RedisClusterEnv
+import org.apache.spark.sql.redis.RedisSourceRelation.dataKey
+import redis.clients.jedis.{HostAndPort, JedisCluster}
 
 /**
   * @author The Viet Nguyen
   */
-class BinaryDataframeClusterSuite extends BinaryDataframeSuite with RedisClusterEnv
+class BinaryDataframeClusterSuite extends BinaryDataframeSuite with RedisClusterEnv {
+
+  override def saveMap(tableName: String, key: String, value: Map[String, String]): Unit = {
+    val host = redisConfig.initialHost
+    val hostAndPort = new HostAndPort(host.host, host.port)
+    val conn = new JedisCluster(hostAndPort)
+    conn.set(dataKey(tableName, key).getBytes(UTF_8), serialize(value))
+    conn.close()
+  }
+}

--- a/src/test/scala/com/redislabs/provider/redis/df/cluster/CsvDataframeClusterSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/cluster/CsvDataframeClusterSuite.scala
@@ -1,0 +1,6 @@
+package com.redislabs.provider.redis.df.cluster
+
+import com.redislabs.provider.redis.df.CsvDataframeSuite
+import com.redislabs.provider.redis.env.RedisClusterEnv
+
+class CsvDataframeClusterSuite extends CsvDataframeSuite with RedisClusterEnv

--- a/src/test/scala/com/redislabs/provider/redis/df/cluster/HashDataframeClusterSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/cluster/HashDataframeClusterSuite.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
   */
 class HashDataframeClusterSuite extends HashDataframeSuite with RedisClusterEnv {
 
-  override def saveHash(tableName: String, key: String, value: Map[String, String]): Unit = {
+  override def saveMap(tableName: String, key: String, value: Map[String, String]): Unit = {
     val host = redisConfig.initialHost
     val hostAndPort = new HostAndPort(host.host, host.port)
     val conn = new JedisCluster(hostAndPort)

--- a/src/test/scala/com/redislabs/provider/redis/df/standalone/BinaryDataframeStandaloneSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/standalone/BinaryDataframeStandaloneSuite.scala
@@ -1,9 +1,21 @@
 package com.redislabs.provider.redis.df.standalone
 
+import java.nio.charset.StandardCharsets.UTF_8
+
 import com.redislabs.provider.redis.df.BinaryDataframeSuite
 import com.redislabs.provider.redis.env.RedisStandaloneEnv
+import com.redislabs.provider.redis.util.ConnectionUtils.withConnection
+import org.apache.spark.sql.redis.RedisSourceRelation.dataKey
 
 /**
   * @author The Viet Nguyen
   */
-class BinaryDataframeStandaloneSuite extends BinaryDataframeSuite with RedisStandaloneEnv
+class BinaryDataframeStandaloneSuite extends BinaryDataframeSuite with RedisStandaloneEnv {
+
+  override def saveMap(tableName: String, key: String, value: Map[String, String]): Unit = {
+    val host = redisConfig.initialHost
+    withConnection(host.connect()) { conn =>
+      conn.set(dataKey(tableName, key).getBytes(UTF_8), serialize(value))
+    }
+  }
+}

--- a/src/test/scala/com/redislabs/provider/redis/df/standalone/HashDataframeStandaloneSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/standalone/HashDataframeStandaloneSuite.scala
@@ -11,7 +11,7 @@ import scala.collection.JavaConverters._
   */
 class HashDataframeStandaloneSuite extends HashDataframeSuite with RedisStandaloneEnv {
 
-  override def saveHash(tableName: String, key: String, value: Map[String, String]): Unit = {
+  override def saveMap(tableName: String, key: String, value: Map[String, String]): Unit = {
     val host = redisConfig.initialHost
     withConnection(host.connect()) { conn =>
       conn.hmset(tableName + ":" + key, value.asJava)

--- a/src/test/scala/com/redislabs/provider/redis/env/RedisClusterEnv.scala
+++ b/src/test/scala/com/redislabs/provider/redis/env/RedisClusterEnv.scala
@@ -11,7 +11,7 @@ trait RedisClusterEnv extends Env {
   override val redisPort = 7379
 
   override val conf: SparkConf = new SparkConf()
-    .setMaster("local").setAppName(getClass.getName)
+    .setMaster("local[*]").setAppName(getClass.getName)
     .set("spark.redis.host", redisHost)
     .set("spark.redis.port", s"$redisPort")
 

--- a/src/test/scala/com/redislabs/provider/redis/env/RedisStandaloneEnv.scala
+++ b/src/test/scala/com/redislabs/provider/redis/env/RedisStandaloneEnv.scala
@@ -9,7 +9,7 @@ import org.apache.spark.SparkConf
 trait RedisStandaloneEnv extends Env {
 
   override val conf: SparkConf = new SparkConf()
-    .setMaster("local").setAppName(getClass.getName)
+    .setMaster("local[*]").setAppName(getClass.getName)
     .set("spark.redis.host", redisHost)
     .set("spark.redis.port", s"$redisPort")
     .set("spark.redis.auth", redisAuth)

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisKeysSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisKeysSuite.scala
@@ -12,7 +12,7 @@ trait RedisKeysSuite extends RedisRddSuite with Keys with Matchers {
 
   test("getKeys - cluster") {
     val returnedKeys = getKeys(redisConfig.hosts, 0, 1024, "*")
-      .asScala.toArray.sorted
+      .toArray.sorted
 
     val targetKeys = (sc.parallelize(content.split("\\W+")).collect :+
       "all:words:cnt:sortedset" :+
@@ -28,7 +28,6 @@ trait RedisKeysSuite extends RedisRddSuite with Keys with Matchers {
 
   test("groupKeysByNode - cluster") {
     val allkeys = getKeys(redisConfig.hosts, 0, 16383, "*")
-      .asScala.iterator
     val nodeKeysPairs = groupKeysByNode(redisConfig.hosts, allkeys)
     val returnedCnt = nodeKeysPairs.map { x =>
       filterKeysByType(x._1.connect(), x._2, "string").length

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisKeysSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisKeysSuite.scala
@@ -36,4 +36,8 @@ trait RedisKeysSuite extends RedisRddSuite with Keys with Matchers {
     val targetCnt = sc.parallelize(content.split("\\W+").filter(!_.isEmpty)).distinct.count
     assert(returnedCnt == targetCnt)
   }
+
+  test("my test") {
+    getKeys(redisConfig.hosts, 0, 16383, "*").foreach(k => println(s"foreach $k"))
+  }
 }

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisKeysSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisKeysSuite.scala
@@ -37,7 +37,4 @@ trait RedisKeysSuite extends RedisRddSuite with Keys with Matchers {
     assert(returnedCnt == targetCnt)
   }
 
-  test("my test") {
-    getKeys(redisConfig.hosts, 0, 16383, "*").foreach(k => println(s"foreach $k"))
-  }
 }

--- a/src/test/scala/com/redislabs/provider/redis/util/Person.scala
+++ b/src/test/scala/com/redislabs/provider/redis/util/Person.scala
@@ -19,12 +19,19 @@ object Person {
     Person("Peter", 35, "110 Wall Street", 200.3)
   )
 
+  val dataMaps = Seq(
+    Map("name" -> "John", "age" -> "30", "address" -> "60 Wall Street", "salary" -> "150.5"),
+    Map("name" -> "Peter", "age" -> "35", "address" -> "110 Wall Street", "salary" -> "200.3")
+  )
+
   val schema = StructType(Array(
     StructField("name", StringType),
     StructField("age", IntegerType),
     StructField("address", StringType),
     StructField("salary", DoubleType)
   ))
+
+  val fullSchema = StructType(schema.fields :+ StructField("_id", StringType))
 
   def df(spark: SparkSession): DataFrame = spark.createDataFrame(data)
 


### PR DESCRIPTION
- ability to filter keys by type before reading, see option `filter.keys.by.type`
- don't materialize (i.e. use iterator) when iterating over underlying RDD partition, use grouped iterator, the size is controlled with `iterator.grouping.size` option 
