### PR TITLE
use JavaConverters to replace JavaConversions

### DIFF
--- a/src/main/scala/com/redislabs/provider/redis/ConnectionPool.scala
+++ b/src/main/scala/com/redislabs/provider/redis/ConnectionPool.scala
@@ -5,14 +5,14 @@ import redis.clients.jedis.exceptions.JedisConnectionException
 
 import java.util.concurrent.ConcurrentHashMap
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 
 object ConnectionPool {
   @transient private lazy val pools: ConcurrentHashMap[RedisEndpoint, JedisPool] =
     new ConcurrentHashMap[RedisEndpoint, JedisPool]()
   def connect(re: RedisEndpoint): Jedis = {
-    val pool = pools.getOrElseUpdate(re,
+    val pool = pools.asScala.getOrElseUpdate(re,
       {
         val poolConfig: JedisPoolConfig = new JedisPoolConfig();
         poolConfig.setMaxTotal(250)

--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -6,7 +6,7 @@ import org.apache.spark.SparkConf
 import redis.clients.jedis.util.{JedisClusterCRC16, JedisURIHelper, SafeEncoder}
 import redis.clients.jedis.{Jedis, Protocol}
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 
 /**
@@ -253,7 +253,7 @@ class RedisConfig(val initialHost: RedisEndpoint) extends Serializable {
     */
   private def getClusterNodes(initialHost: RedisEndpoint): Array[RedisNode] = {
     val conn = initialHost.connect()
-    val res = conn.clusterSlots().flatMap {
+    val res = conn.clusterSlots().asScala.flatMap {
       slotInfoObj => {
         val slotInfo = slotInfoObj.asInstanceOf[java.util.List[java.lang.Object]]
         val sPos = slotInfo.get(0).toString.toInt
@@ -268,7 +268,7 @@ class RedisConfig(val initialHost: RedisEndpoint) extends Serializable {
          * filter master.
          */
         (0 until (slotInfo.size - 2)).map(i => {
-          val node = slotInfo(i + 2).asInstanceOf[java.util.List[java.lang.Object]]
+          val node = slotInfo.asScala(i + 2).asInstanceOf[java.util.List[java.lang.Object]]
           val host = SafeEncoder.encode(node.get(0).asInstanceOf[Array[scala.Byte]])
           val port = node.get(1).toString.toInt
           RedisNode(RedisEndpoint(host, port, initialHost.auth, initialHost.dbNum,

--- a/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
@@ -16,7 +16,6 @@ import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import redis.clients.jedis.{PipelineBase, Protocol}
 
-import scala.collection.JavaConversions._
 import scala.collection.JavaConverters._
 
 class RedisSourceRelation(override val sqlContext: SQLContext,
@@ -72,7 +71,7 @@ class RedisSourceRelation(override val sqlContext: SQLContext,
   private val keysPatternOpt: Option[String] = parameters.get(SqlOptionKeysPattern)
   private val numPartitions = parameters.get(SqlOptionNumPartitions).map(_.toInt)
     .getOrElse(SqlOptionNumPartitionsDefault)
-  private val persistenceModel = parameters.getOrDefault(SqlOptionModel, SqlOptionModelHash)
+  private val persistenceModel = parameters.asJava.getOrDefault(SqlOptionModel, SqlOptionModelHash)
   private val persistence = RedisPersistence(persistenceModel)
   private val tableNameOpt: Option[String] = parameters.get(SqlOptionTableName)
   private val ttl = parameters.get(SqlOptionTTL).map(_.toInt).getOrElse(0)

--- a/src/test/scala/com/redislabs/provider/redis/stream/RedisXStreamSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/stream/RedisXStreamSuite.scala
@@ -10,7 +10,7 @@ import org.scalatest.concurrent.Eventually._
 import org.scalatest.time.{Millis, Span}
 import redis.clients.jedis.EntryID
 
-import scala.collection.JavaConversions._
+import scala.collection.JavaConverters._
 
 trait RedisXStreamSuite extends SparkStreamingRedisSuite with Matchers {
 
@@ -40,9 +40,9 @@ trait RedisXStreamSuite extends SparkStreamingRedisSuite with Matchers {
 
     // write to stream
     withConnection(redisConfig.connectionForKey(streamKey)) { conn =>
-      conn.xadd(streamKey, new EntryID(1, 0), Map("a" -> "1", "z" -> "4"))
-      conn.xadd(streamKey, new EntryID(1, 1), Map("b" -> "2"))
-      conn.xadd(streamKey, new EntryID(2, 0), Map("c" -> "3"))
+      conn.xadd(streamKey, new EntryID(1, 0), Map("a" -> "1", "z" -> "4").asJava)
+      conn.xadd(streamKey, new EntryID(1, 1), Map("b" -> "2").asJava)
+      conn.xadd(streamKey, new EntryID(2, 0), Map("c" -> "3").asJava)
     }
 
     ssc.start()
@@ -85,9 +85,9 @@ trait RedisXStreamSuite extends SparkStreamingRedisSuite with Matchers {
 
     // write to stream
     withConnection(redisConfig.connectionForKey(streamKey)) { conn =>
-      conn.xadd(streamKey, new EntryID(1, 0), Map("a" -> "1", "z" -> "4"))
-      conn.xadd(streamKey, new EntryID(1, 1), Map("b" -> "2"))
-      conn.xadd(streamKey, new EntryID(2, 0), Map("c" -> "3"))
+      conn.xadd(streamKey, new EntryID(1, 0), Map("a" -> "1", "z" -> "4").asJava)
+      conn.xadd(streamKey, new EntryID(1, 1), Map("b" -> "2").asJava)
+      conn.xadd(streamKey, new EntryID(2, 0), Map("c" -> "3").asJava)
     }
 
     ssc.start()
@@ -136,11 +136,11 @@ trait RedisXStreamSuite extends SparkStreamingRedisSuite with Matchers {
 
     // write to stream
     withConnection(redisConfig.connectionForKey(stream1Key)) { conn =>
-      conn.xadd(stream1Key, new EntryID(1, 0), Map("a" -> "1", "z" -> "4"))
+      conn.xadd(stream1Key, new EntryID(1, 0), Map("a" -> "1", "z" -> "4").asJava)
     }
     withConnection(redisConfig.connectionForKey(stream2Key)) { conn =>
-      conn.xadd(stream2Key, new EntryID(1, 1), Map("b" -> "2"))
-      conn.xadd(stream2Key, new EntryID(2, 0), Map("c" -> "3"))
+      conn.xadd(stream2Key, new EntryID(1, 1), Map("b" -> "2").asJava)
+      conn.xadd(stream2Key, new EntryID(2, 0), Map("c" -> "3").asJava)
     }
 
     ssc.start()


### PR DESCRIPTION
As https://github.com/scala/scala/pull/5109 says, JavaConversions will be deprecated, so I replace JavaConversions by JavaConverters.