### PR TITLE
suppress spark errors in a unit tests output

### DIFF
--- a/src/test/scala/com/redislabs/provider/redis/df/BinaryDataframeSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/BinaryDataframeSuite.scala
@@ -37,7 +37,7 @@ trait BinaryDataframeSuite extends RedisDataframeSuite with Matchers {
       .option(SqlOptionModel, SqlOptionModelBinary)
       .option(SqlOptionTableName, tableName)
       .save()
-    intercept[SparkException] {
+    interceptSparkErr[SparkException] {
       spark.read.format(RedisFormat)
         .option(SqlOptionTableName, tableName)
         .load()
@@ -51,7 +51,7 @@ trait BinaryDataframeSuite extends RedisDataframeSuite with Matchers {
     df.write.format(RedisFormat)
       .option(SqlOptionTableName, tableName)
       .save()
-    intercept[SparkException] {
+    interceptSparkErr[SparkException] {
       spark.read.format(RedisFormat)
         .option(SqlOptionModel, SqlOptionModelBinary)
         .option(SqlOptionTableName, tableName)
@@ -93,7 +93,7 @@ trait BinaryDataframeSuite extends RedisDataframeSuite with Matchers {
       .option(SqlOptionModel, SqlOptionModelHash)
       .save()
     saveMap(tableName, RedisSourceRelation.uuid(), Person.dataMaps.head)
-    intercept[SparkException] {
+    interceptSparkErr[SparkException] {
       spark.read.format(RedisFormat)
         .option(SqlOptionTableName, tableName)
         .option(SqlOptionModel, SqlOptionModelHash)

--- a/src/test/scala/com/redislabs/provider/redis/df/DataframeSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/DataframeSuite.scala
@@ -148,7 +148,7 @@ trait DataframeSuite extends RedisDataframeSuite with Matchers {
       .option(SqlOptionTableName, tableName)
       .save()
     // the modified information should not be persisted
-    intercept[IllegalStateException] {
+    interceptSparkErr[IllegalStateException] {
       spark.createDataFrame(data.map(p => p.copy(age = p.age + 1)))
         .write.format(RedisFormat)
         .option(SqlOptionTableName, tableName)

--- a/src/test/scala/com/redislabs/provider/redis/df/HashDataframeSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/df/HashDataframeSuite.scala
@@ -284,7 +284,7 @@ trait HashDataframeSuite extends RedisDataframeSuite with Matchers {
       .option(SqlOptionModel, SqlOptionModelBinary)
       .save()
     saveMap(tableName, extraKey, Person.dataMaps.head)
-    intercept[SparkException] {
+    interceptSparkErr[SparkException] {
       spark.read.format(RedisFormat)
         .schema(Person.fullSchema)
         .option(SqlOptionTableName, tableName)

--- a/src/test/scala/com/redislabs/provider/redis/util/TestUtils.scala
+++ b/src/test/scala/com/redislabs/provider/redis/util/TestUtils.scala
@@ -2,6 +2,9 @@ package com.redislabs.provider.redis.util
 
 import java.util.UUID
 
+import org.scalatest.Assertions
+import scala.reflect.Manifest
+
 object TestUtils {
 
   def generateTableName(prefix: String): String = {
@@ -12,5 +15,25 @@ object TestUtils {
   def generateRandomKey(): String = {
     UUID.randomUUID().toString.replace("-", "")
   }
+
+  /**
+    * A wrapper of Assertions.intercept() that suppresses spark errors in the logs.
+    * It makes easier to analyse unit tests output.
+    */
+  def interceptSparkErr[T <: AnyRef](f: => Any)(implicit manifest: Manifest[T]): T = {
+    // turn off spark logger
+    val logger = org.apache.log4j.Logger.getLogger("org")
+    val levelBefore = logger.getLevel
+    logger.setLevel(org.apache.log4j.Level.OFF)
+
+    // delegate interception
+    val interceptRes = Assertions.intercept(f)
+
+    // revert logger
+    logger.setLevel(levelBefore)
+
+    interceptRes
+  }
+
 
 }


### PR DESCRIPTION
It makes easier to analyze unit tests output when something fails.