### PR TITLE
issue #188: fix travis build. Travis upgraded the default installed j…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: required
 language: scala
+jdk:
+    - openjdk8
 scala:
     - 2.11.2
 install:


### PR DESCRIPTION
…ava version from 8 to 11. This caused a build issue. For now revert back to using openjdk 8 until we fix it for openjdk 11.