### PR TITLE
Issue 257

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -6,7 +6,7 @@ The supported configuration parameters are:
 topology from the initial node, so there is no need to provide the rest of the cluster nodes.
 * `spark.redis.port` - the initial node's TCP redis port.
 * `spark.redis.auth` - the initial node's AUTH password
-* `spark.redis.db` - optional DB number. Avoid using this, especially in cluster mode.
+* `spark.redis.dbNum` - optional DB number. Avoid using this, especially in cluster mode.
 * `spark.redis.timeout` - connection timeout in ms, 2000 ms by default
 * `spark.redis.max.pipeline.size` - the maximum number of commands per pipeline (used to batch commands). The default value is 100.
 * `spark.redis.scan.count` - count option of SCAN command (used to iterate over keys). The default value is 100.

--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -37,7 +37,7 @@ case class RedisEndpoint(host: String = Protocol.DEFAULT_HOST,
       conf.get("spark.redis.host", Protocol.DEFAULT_HOST),
       conf.getInt("spark.redis.port", Protocol.DEFAULT_PORT),
       conf.get("spark.redis.auth", null),
-      conf.getInt("spark.redis.db", Protocol.DEFAULT_DATABASE),
+      conf.getInt("spark.redis.dbNum", Protocol.DEFAULT_DATABASE),
       conf.getInt("spark.redis.timeout", Protocol.DEFAULT_TIMEOUT),
       conf.getBoolean("spark.redis.ssl", false)
     )

--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -28,7 +28,7 @@ case class RedisEndpoint(host: String = Protocol.DEFAULT_HOST,
   extends Serializable {
 
   /**
-    * Constructor from spark config. set params with spark.redis.host, spark.redis.port, spark.redis.auth, spark.redis.db and spark.redis.ssl
+    * Constructor from spark config. set params with spark.redis.host, spark.redis.port, spark.redis.auth, spark.redis.dbNum and spark.redis.ssl
     *
     * @param conf spark context config
     */


### PR DESCRIPTION

* Issue is mostly related to a typo: `spark.redis.db` instead of `spark.redis.dbNum` in the code and some part of the documentation

* I have only tested manually