### PR TITLE
fix arg exception msg in redis source relation

### DIFF
--- a/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
@@ -102,7 +102,7 @@ class RedisSourceRelation(override val sqlContext: SQLContext,
 
   // check specified parameters
   if (tableNameOpt.isDefined && keysPatternOpt.isDefined) {
-    throw new IllegalArgumentException(s"Both options '$SqlOptionTableName' and '$SqlOptionTableName' are set. " +
+    throw new IllegalArgumentException(s"Both options '$SqlOptionKeysPattern' and '$SqlOptionTableName' are set. " +
       s"You should only use either one.")
   }
 


### PR DESCRIPTION
The argument exception msg prints out the wrong variable. 
SqlOptionKeysPattern and SqlOptionTable can not be set but the exception msg prints out
SqlOptionTable and SqlOptionTable