### PR TITLE
Allow to override Redis options for spark.readStream

### DIFF
--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -43,6 +43,24 @@ case class RedisEndpoint(host: String = Protocol.DEFAULT_HOST,
     )
   }
 
+
+  /**
+   * Constructor from spark config and parameters.
+   *
+   * @param conf spark context config
+   * @param parameters source specific parameters
+   */
+  def this(conf: SparkConf, parameters: Map[String, String]) {
+    this(
+      parameters.getOrElse("host", conf.get("spark.redis.host", Protocol.DEFAULT_HOST)),
+      parameters.getOrElse("port", conf.get("spark.redis.port", Protocol.DEFAULT_PORT.toString)).toInt,
+      parameters.getOrElse("auth", conf.get("spark.redis.auth", null)),
+      parameters.getOrElse("dbNum", conf.get("spark.redis.db", Protocol.DEFAULT_DATABASE.toString)).toInt,
+      parameters.getOrElse("timeout", conf.get("spark.redis.timeout", Protocol.DEFAULT_TIMEOUT.toString)).toInt,
+      parameters.getOrElse("ssl", conf.get("spark.redis.ssl", false.toString)).toBoolean)
+  }
+
+
   /**
     * Constructor with Jedis URI
     *
@@ -121,6 +139,10 @@ object RedisConfig {
     */
   def fromSparkConf(conf: SparkConf): RedisConfig = {
     new RedisConfig(new RedisEndpoint(conf))
+  }
+
+  def fromSparkConfAndParameters(conf: SparkConf, parameters: Map[String, String]): RedisConfig = {
+    new RedisConfig(new RedisEndpoint(conf, parameters))
   }
 }
 

--- a/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
@@ -30,21 +30,8 @@ class RedisSourceRelation(override val sqlContext: SQLContext,
     with Serializable
     with Logging {
 
-  private implicit val redisConfig: RedisConfig = {
-    new RedisConfig(
-      if ((parameters.keySet & Set("host", "port", "auth", "dbNum", "timeout")).isEmpty) {
-        new RedisEndpoint(sqlContext.sparkContext.getConf)
-      } else {
-        val host = parameters.getOrElse("host", Protocol.DEFAULT_HOST)
-        val port = parameters.get("port").map(_.toInt).getOrElse(Protocol.DEFAULT_PORT)
-        val auth = parameters.getOrElse("auth", null)
-        val dbNum = parameters.get("dbNum").map(_.toInt).getOrElse(Protocol.DEFAULT_DATABASE)
-        val timeout = parameters.get("timeout").map(_.toInt).getOrElse(Protocol.DEFAULT_TIMEOUT)
-        val ssl = parameters.get("ssl").map(_.toBoolean).getOrElse(false)
-        RedisEndpoint(host, port, auth, dbNum, timeout, ssl)
-      }
-    )
-  }
+  private implicit val redisConfig: RedisConfig = RedisConfig.fromSparkConfAndParameters(
+    sqlContext.sparkContext.getConf, parameters)
 
   implicit private val readWriteConfig: ReadWriteConfig = {
     val global = ReadWriteConfig.fromSparkConf(sqlContext.sparkContext.getConf)

--- a/src/main/scala/org/apache/spark/sql/redis/stream/RedisSource.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/stream/RedisSource.scala
@@ -25,7 +25,7 @@ class RedisSource(sqlContext: SQLContext, metadataPath: String,
 
   private val sc = sqlContext.sparkContext
 
-  implicit private val redisConfig: RedisConfig = RedisConfig.fromSparkConf(sc.getConf)
+  implicit private val redisConfig: RedisConfig = RedisConfig.fromSparkConfAndParameters(sc.getConf, parameters)
 
   private val sourceConfig = RedisSourceConfig.fromMap(parameters)
 


### PR DESCRIPTION
It's possible to override the Redis options for specific `spark.read` operation, but it's
impossible to do for the `spark.readStream`.   This PR allows to do that, unifying the
implementation of doing that.