### PR TITLE
Adding toRedisByteHASHes from spark-redis#304 to spark-redis 2.x

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -11,6 +11,7 @@ topology from the initial node, so there is no need to provide the rest of the c
 * `spark.redis.timeout` - connection timeout in ms, 2000 ms by default
 * `spark.redis.max.pipeline.size` - the maximum number of commands per pipeline (used to batch commands). The default value is 100.
 * `spark.redis.scan.count` - count option of SCAN command (used to iterate over keys). The default value is 100.
+* `spark.redis.rdd.write.iterator.grouping.size` - applied for RDD write operations, the number of items to be grouped when iterating over underlying RDD partition
 * `spark.redis.ssl` - set to true to use tls
 
 

--- a/doc/rdd.md
+++ b/doc/rdd.md
@@ -145,6 +145,12 @@ sc.toRedisHASHes(hashRDD, ttl)
 
 The `hashRDD` is a rdd of tuples (`hashname`, `map[field name, field value]`)
 
+```scala
+sc.toRedisByteHASHes(hashRDD, ttl)
+```
+
+The `hashRDD` is a rdd of tuples (`hashname`, `map[field name, field value]`) represented as byte arrays.
+
 #### Lists
 Use the following to store an RDD in a Redis List:
 

--- a/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
+++ b/src/main/scala/com/redislabs/provider/redis/RedisConfig.scala
@@ -96,7 +96,7 @@ case class RedisNode(endpoint: RedisEndpoint,
 /**
   * Tuning options for read and write operations.
   */
-case class ReadWriteConfig(scanCount: Int, maxPipelineSize: Int)
+case class ReadWriteConfig(scanCount: Int, maxPipelineSize: Int, rddWriteIteratorGroupingSize: Int)
 
 object ReadWriteConfig {
   /** maximum number of commands per pipeline **/
@@ -107,12 +107,17 @@ object ReadWriteConfig {
   val ScanCountConfKey = "spark.redis.scan.count"
   val ScanCountDefault = 100
 
-  val Default: ReadWriteConfig = ReadWriteConfig(ScanCountDefault, MaxPipelineSizeDefault)
+  /** Iterator grouping size for writing RDD **/
+  val RddWriteIteratorGroupingSizeKey = "spark.redis.rdd.write.iterator.grouping.size"
+  val RddWriteIteratorGroupingSizeDefault = 1000
+
+  val Default: ReadWriteConfig = ReadWriteConfig(ScanCountDefault, MaxPipelineSizeDefault, RddWriteIteratorGroupingSizeDefault)
 
   def fromSparkConf(conf: SparkConf): ReadWriteConfig = {
     ReadWriteConfig(
       conf.getInt(ScanCountConfKey, ScanCountDefault),
-      conf.getInt(MaxPipelineSizeConfKey, MaxPipelineSizeDefault)
+      conf.getInt(MaxPipelineSizeConfKey, MaxPipelineSizeDefault),
+      conf.getInt(RddWriteIteratorGroupingSizeKey, RddWriteIteratorGroupingSizeDefault)
     )
   }
 }

--- a/src/main/scala/org/apache/spark/sql/redis/redis.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/redis.scala
@@ -7,6 +7,9 @@ package object redis {
 
   val RedisFormat = "org.apache.spark.sql.redis"
 
+  val RddWriteIteratorGroupingSize = "rdd.write.iterator.grouping.size"
+  val RddWriteIteratorGroupingSizeDefault = 1000
+
   val SqlOptionFilterKeysByType = "filter.keys.by.type"
   val SqlOptionNumPartitions = "partitions.number"
   /**

--- a/src/test/scala/com/redislabs/provider/redis/rdd/RedisRddExtraSuite.scala
+++ b/src/test/scala/com/redislabs/provider/redis/rdd/RedisRddExtraSuite.scala
@@ -58,6 +58,21 @@ trait RedisRddExtraSuite extends SparkRedisSuite with Keys with Matchers {
     verifyHash("hash2", map2)
   }
 
+  test("toRedisByteHASHes") {
+    val map1 = Map("k1" -> "v1", "k2" -> "v2")
+    val map2 = Map("k3" -> "v3", "k4" -> "v4")
+    val hashes = Seq(
+      ("hash1", map1),
+      ("hash2", map2)
+    )
+    val hashesBytes = hashes.map { case (k, hash) => (k.getBytes, hash.map { case (mapKey, mapVal) => (mapKey.getBytes, mapVal.getBytes) }) }
+    val rdd = sc.parallelize(hashesBytes)
+    sc.toRedisByteHASHes(rdd)
+
+    verifyHash("hash1", map1)
+    verifyHash("hash2", map2)
+  }
+
   test("connection fails with incorrect user/pass") {
     assertThrows[JedisConnectionException] {
       new RedisConfig(RedisEndpoint(


### PR DESCRIPTION
Changes from #304 were only added to spark-redis 3.x which is built with Scala 2.12.
Opened this pull request with changes applied by @fe2s so we have it available with spark-redis 2.x and Scala 2.11.