### PR TITLE
fix #354: Notify user when dataframe contains only key column

### DIFF
--- a/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
@@ -136,6 +136,10 @@ class RedisSourceRelation(override val sqlContext: SQLContext,
         }
       }
     }
+    // If dataframe contains only key column
+    if (fields.size() < 2) {
+      logInfo(s"Dataframe only contains key.column specified in options. No data was writen to redis.")
+    }
   }
 
   override def buildScan(requiredColumns: Array[String], filters: Array[Filter]): RDD[Row] = {

--- a/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
@@ -137,7 +137,8 @@ class RedisSourceRelation(override val sqlContext: SQLContext,
       }
     }
     // If dataframe contains only key column
-    if (fields.size() < 2) {
+    val colCount = data.columns.length
+    if (colCount < 2) {
       logInfo(s"Dataframe only contains key.column specified in options. No data was writen to redis.")
     }
   }


### PR DESCRIPTION
This PR will help notify the user about no data being writen as the dataframe only contained key column.