### PR TITLE
Fixed Redis config initial host printing.

### DIFF
--- a/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
+++ b/src/main/scala/org/apache/spark/sql/redis/RedisSourceRelation.scala
@@ -42,7 +42,7 @@ class RedisSourceRelation(override val sqlContext: SQLContext,
     )
   }
 
-  logInfo(s"Redis config initial host: ${redisConfig.initialHost}")
+  logInfo(s"Redis config initial host: ${redisConfig.initialHost.host}")
 
   @transient private val sc = sqlContext.sparkContext
 


### PR DESCRIPTION
Address the issue of Redis credentials being unintentionally revealed in logs.